### PR TITLE
Update/auth0-lock: Add hidden type and storage property support for signup fields

### DIFF
--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -35,6 +35,7 @@ interface Auth0LockAdditionalTextSignUpField {
     placeholder: string;
     prefill?: string | Auth0LockAdditionalSignUpFieldPrefillFunction;
     validator?: (input: string) => { valid: boolean; hint?: string };
+    storage?: "root";
 }
 
 interface Auth0LockAdditionalSelectSignUpField {
@@ -45,6 +46,7 @@ interface Auth0LockAdditionalSelectSignUpField {
     placeholder: string;
     prefill?: string | Auth0LockAdditionalSignUpFieldPrefillFunction;
     validator?: (input: string) => { valid: boolean; hint?: string };
+    storage?: "root";
 }
 
 interface Auth0LockAdditionalCheckboxSignUpField {
@@ -54,9 +56,17 @@ interface Auth0LockAdditionalCheckboxSignUpField {
     placeholder: string;
     prefill: "true" | "false";
     validator?: (input: string) => { valid: boolean, hint?: string };
+    storage?: "root";
 }
 
-type Auth0LockAdditionalSignUpField = Auth0LockAdditionalSelectSignUpField |Auth0LockAdditionalTextSignUpField |Auth0LockAdditionalCheckboxSignUpField;
+interface Auth0LockAdditionalHiddenSignUpField {
+    type?: "hidden";
+    name: string;
+    value: string;
+    storage?: "root";
+}
+
+type Auth0LockAdditionalSignUpField = Auth0LockAdditionalSelectSignUpField |Auth0LockAdditionalTextSignUpField |Auth0LockAdditionalCheckboxSignUpField |Auth0LockAdditionalHiddenSignUpField;
 
 type Auth0LockAvatarUrlCallback = (error: auth0.Auth0Error, url: string) => void;
 type Auth0LockAvatarDisplayNameCallback = (error: auth0.Auth0Error, displayName: string) => void;


### PR DESCRIPTION
According to https://auth0.com/docs/libraries/lock/lock-configuration#hidden-field there's a hidden field type available.
This type is currently missing from the types.
According to https://auth0.com/docs/libraries/lock/lock-configuration#text-fields there's also a storage property which can be set to "root". It's only documented on the text field type but I'm not sure if this is accurate since the limitation on it's usage base on the field name and not necessarily on the field type. 
Hence I added the storage property to all types.

